### PR TITLE
Fix `render :text` deprecation

### DIFF
--- a/lib/declarative_authorization/in_controller.rb
+++ b/lib/declarative_authorization/in_controller.rb
@@ -132,7 +132,7 @@ module Authorization
           # permission_denied needs to render or redirect
           send(:permission_denied)
         else
-          send(:render, :text => "You are not allowed to access this action.",
+          send(:render, :plain => "You are not allowed to access this action.",
             :status => :forbidden)
         end
       end


### PR DESCRIPTION
**Addresses the following deprecation warning in Rails 5:**

DEPRECATION WARNING: `render :text` is deprecated because it does not actually render a `text/plain` response. Switch to `render plain: 'plain text'` to render as `text/plain`, `render html: '<strong>HTML</strong>'` to render as `text/html`, or `render body: 'raw'` to match the deprecated behavior and render with the default Content-Type, which is `text/html`.